### PR TITLE
Added a method for resetting the animation

### DIFF
--- a/kyrie/src/main/java/com/github/alexjlockwood/kyrie/KyrieDrawable.kt
+++ b/kyrie/src/main/java/com/github/alexjlockwood/kyrie/KyrieDrawable.kt
@@ -334,6 +334,11 @@ class KyrieDrawable private constructor(
         animator.resume()
     }
 
+    /** Resets the animation. */
+    fun reset() {
+        animator.currentPlayTime = 0
+    }
+
     /** Returns true if the animation is running. */
     override fun isRunning(): Boolean {
         return animator.isRunning


### PR DESCRIPTION
I stumbled upon this library while looking for a way to reset AnimatedVectorDrawable to its initial state. I found [this](https://www.reddit.com/r/androiddev/comments/g029bu/how_to_reset_animation_using/) thread on Reddit where Nick Butcher recommends your library. I was surprised to find that Kyrie didn't have a reset function. After digging a little deeper, I discovered that I can simply reset the currentPlayTime to zero. However, I still think it's valuable to have a more straight forward way to do this.